### PR TITLE
Fixed bug with for-loop for reverting to catalog values

### DIFF
--- a/convert_mcmc_quant_to_jld2.jl
+++ b/convert_mcmc_quant_to_jld2.jl
@@ -90,17 +90,17 @@ koi = join(catalog,quantiles_df, on=:kepoi_name)
 koi[:mcmc_good] = trues(size(koi,1))
 
 # If mcmc sample wasn't adequate to provide quantiles, revert to catalog values
-for i in size(quantiles_df,1)
+for i in 1:size(quantiles_df,1)
     if koi[i,:koi_depth] < 0
-        koi[i,:koi_depth] = koi[i,:koi_depth_cat]
-        koi[i,:koi_depth_err1] = koi[i,:koi_depth_err1_cat]
-        koi[i,:koi_depth_err2] = koi[i,:koi_depth_err2_cat]
+        koi[i,:koi_depth] = ismissing(koi[i,:koi_depth_cat]) ? -1 : koi[i,:koi_depth_cat]
+        koi[i,:koi_depth_err1] = ismissing(koi[i,:koi_depth_err1_cat]) ? -1 : koi[i,:koi_depth_err1_cat]
+        koi[i,:koi_depth_err2] = ismissing(koi[i,:koi_depth_err2_cat]) ? -1 : koi[i,:koi_depth_err2_cat]
         koi[i,:mcmc_good] = false
     end
     if koi[i,:koi_duration] < 0
-        koi[i,:koi_duration] = koi[i,:koi_duration_cat]
-        koi[i,:koi_duration_err1] = koi[i,:koi_duration_err1_cat]
-        koi[i,:koi_duration_err2] = koi[i,:koi_duration_err2_cat]
+        koi[i,:koi_duration] = ismissing(koi[i,:koi_duration_cat]) ? -1 : koi[i,:koi_duration_cat]
+        koi[i,:koi_duration_err1] = ismissing(koi[i,:koi_duration_err1_cat]) ? -1 : koi[i,:koi_duration_err1_cat]
+        koi[i,:koi_duration_err2] = ismissing(koi[i,:koi_duration_err2_cat]) ? -1 : koi[i,:koi_duration_err2_cat]
         koi[i,:mcmc_good] = false
     end
 end


### PR DESCRIPTION
I ran your script to generate a "q1_q17_dr25_koi.jld2" file but I was confused when it included a bunch of negative values for the transit depths and durations, and then I realized that it didn't actually loop through to revert to catalog values if the mcmc gave negative values. So I've fixed that, but there are cases where the mcmc gives a negative value AND the catalog includes a missing value, so I just decided to treat those by setting them to -1 (since `koi[:koi_depth]` and `koi[:koi_duration]` are Array{Float64,1} so I can't put Missing values in them).

Thanks